### PR TITLE
Port code from gofer/proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ language: node_js
 node_js:
   - '0.10'
   - '4'
+env:
+  - GOFER=2
+  - GOFER=3
 before_install:
   - npm install -g npm@latest-2
+before_script:
+  - npm install "gofer@$GOFER"
 # before_deploy:
 #   - git config --global user.email "jan.krems@groupon.com"
 #   - git config --global user.name "Jan Krems"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,29 @@
 # `gofer-proxy`
 
-Allows you to expose service endpoints in an express app.
+A companion to [`gofer`](https://github.com/groupon/gofer)
+that allows you to expose service endpoints in an express app.
+
+```bash
+npm install --save gofer-proxy
+```
+
+### Features
+
+* Removes `callback` parameters from the query to disallow JSONP.
+* Hides server and network errors by passing them down the middleware chain.
+* Handles both gofer 2.x and gofer 3.x clients.
+* Honors all the config & option mappers of the service client.
+
+### Usage
 
 ```js
-const goferProxy = require('gofer-proxy');
-const myClient = new MyClient(config);
-app.use('/some/prefix', (req, res, next) => {
+var goferProxy = require('gofer-proxy');
+
+// `MyClient` is a class derived from Gofer
+var myClient = new MyClient(config);
+
+// `app` is an expressjs application
+app.use('/some/prefix', function (req, res, next) {
   goferProxy(myClient, req, res, next);
 });
 ```

--- a/lib/gofer-proxy.js
+++ b/lib/gofer-proxy.js
@@ -44,13 +44,16 @@ function goferProxy(client, req, res, next) {
     body: req,
     qs: _.omit(parsed.query, 'callback'),
     minStatusCode: 200,
-    maxStatusCode: 399
+    maxStatusCode: 499
   };
   var proxyReq = client.fetch(parsed.pathname, options);
 
   function handleProxyResponse(proxyRes) {
     return new Bluebird(function forward(resolve, reject) {
       proxyRes.on('error', reject);
+      if ('statusCode' in proxyRes) {
+        res.statusCode = proxyRes.statusCode;
+      }
       proxyRes.pipe(res);
       return proxyRes.on('end', resolve);
     });

--- a/lib/gofer-proxy.js
+++ b/lib/gofer-proxy.js
@@ -29,4 +29,65 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+/*
+Copyright (c) 2014, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 'use strict';
+var url = require('url');
+
+var Bluebird = require('bluebird');
+var _ = require('lodash');
+
+function goferProxy(client, req, res, next) {
+  var parsed = url.parse(req.url, true);
+  var options = {
+    method: req.method,
+    headers: _.omit(req.headers, 'host'),
+    body: req,
+    qs: _.omit(parsed.query, 'callback'),
+    minStatusCode: 200,
+    maxStatusCode: 399
+  };
+  var proxyReq = client.fetch(parsed.pathname, options);
+
+  function handleProxyResponse(proxyRes) {
+    return new Bluebird(function forward(resolve, reject) {
+      proxyRes.on('error', reject);
+      proxyRes.pipe(res);
+      return proxyRes.on('end', resolve);
+    });
+  }
+  var piped = typeof proxyReq.pipe === 'function' ?
+    handleProxyResponse(proxyReq) : proxyReq.then(handleProxyResponse);
+  piped.then(null, next);
+}
+module.exports = goferProxy;

--- a/lib/gofer-proxy.js
+++ b/lib/gofer-proxy.js
@@ -30,37 +30,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
-Copyright (c) 2014, Groupon, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-Neither the name of GROUPON nor the names of its contributors may be
-used to endorse or promote products derived from this software without
-specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 'use strict';
 var url = require('url');
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
       ]
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "bluebird": "^3.4.6",
+    "lodash": "^4.15.0"
+  },
   "devDependencies": {
     "assertive": "^2.0.0",
     "eslint": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "eslint": "^2.0.0",
     "eslint-config-groupon-es5": "^3.0.0",
     "eslint-plugin-import": "^1.6.1",
+    "express": "^4.14.0",
+    "gofer": "^2.6.0",
     "mocha": "^2.0.0",
     "nlm": "^2.0.0"
   },

--- a/test/gofer-proxy.test.js
+++ b/test/gofer-proxy.test.js
@@ -1,10 +1,181 @@
 'use strict';
+var http = require('http');
+
 var assert = require('assertive');
+var express = require('express');
+var Gofer = require('gofer');
+var goferVersion = require('gofer/package.json').version;
 
 var goferProxy = require('../');
 
-describe('gofer-proxy', function () {
-  it('is a function', function () {
-    assert.hasType(Function, goferProxy);
+var IS_GOFER2 = /^2\./.test(goferVersion);
+
+function makeGofer(ctor, name) {
+  ctor.prototype = Object.create(Gofer.prototype);
+  if (IS_GOFER2) {
+    ctor.prototype.serviceName = name;
+  }
+}
+
+function EchoClient(config) {
+  Gofer.call(this, config, IS_GOFER2 ? null : 'echo');
+}
+makeGofer(EchoClient, 'echo');
+
+EchoClient.prototype.addOptionMapper(function (options) {
+  if (options.headers['x-fail-mapper']) {
+    throw new Error('OptionMapperError');
+  }
+
+  return options;
+});
+
+function ProxyClient(config) {
+  Gofer.call(this, config, IS_GOFER2 ? null : 'proxy');
+}
+makeGofer(ProxyClient, 'proxy');
+
+describe('goferProxy', function () {
+  var echoClient;
+  var proxyClient;
+
+  before('setup echo app', function (done) {
+    var echoServer = http.createServer(function (req, res) {
+      if (req.url.indexOf('network-error') !== -1) {
+        req.socket.destroy();
+        return; // ECONNRESET;
+      }
+
+      if (req.headers['if-none-match']) {
+        res.statusCode = 304;
+        res.end();
+        return;
+      }
+
+      if (req.url.indexOf('server-error') !== -1) {
+        res.statusCode = 401;
+      }
+      res.setHeader('Content-Type', 'application/json');
+
+      var chunks = [];
+      req.on('data', function (chunk) { chunks.push(chunk); });
+      req.on('end', function () {
+        res.end(JSON.stringify({
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body: Buffer.concat(chunks).toString('utf8')
+        }));
+      });
+    });
+
+    echoServer.listen(0, function () {
+      echoClient = new EchoClient({
+        echo: {
+          baseUrl: 'http://127.0.0.1:' + echoServer.address().port + '/other/base',
+          qs: { client_id: 'some-client-id' }
+        }
+      });
+      done();
+    });
+  });
+
+  before('setup proxy app', function (done) {
+    var proxyApp = express();
+    proxyApp.use('/api/v2', function (req, res, next) {
+      goferProxy(echoClient, req, res, next);
+    });
+
+    proxyApp.use(function (err, req, res, next) { // eslint-disable-line no-unused-vars
+      res.statusCode = 500;
+      res.json({
+        fromErrorMiddleware: true,
+        message: err.message,
+        code: err.code,
+        syscall: err.syscall
+      });
+    });
+
+    var proxyServer = http.createServer(proxyApp);
+    proxyServer.listen(0, function () {
+      proxyClient = new ProxyClient({
+        proxy: {
+          minStatusCode: 200,
+          maxStatusCode: 599,
+          baseUrl: 'http://127.0.0.1:' + proxyServer.address().port
+        }
+      });
+      done();
+    });
+  });
+
+  describe('successful request', function () {
+    var reqEcho;
+
+    before(function (done) {
+      proxyClient.fetch('/api/v2/some/path?x=42', {
+        method: 'POST',
+        json: { some: { body: 'data' } },
+        qs: { more: 'query stuff' }
+      }, function (err, data) {
+        reqEcho = data;
+        done(err);
+      });
+    });
+
+    it('forwards the method', function () {
+      assert.equal('POST', reqEcho.method);
+    });
+
+    it('removes the middleware mount point from the url', function () {
+      var urlParts = reqEcho.url.split('?');
+      assert.equal('/other/base/some/path', urlParts[0]);
+      assert.equal('client_id=some-client-id&x=42&more=query%20stuff', urlParts[1]);
+    });
+
+    it('forwards the request body', function () {
+      assert.equal('{"some":{"body":"data"}}', reqEcho.body);
+    });
+  });
+
+  it('forwards 304s', function () {
+    proxyClient.fetch('/api/v2/not-modified', {
+      headers: { 'if-none-match': 'last-etag' }
+    }).asPromise().then(function (results) {
+      assert.equal(304, results[0].statusCode);
+      assert.equal('', results[1]);
+    });
+  });
+
+  it('fails cleanly with a throwing option mapper', function () {
+    proxyClient.fetch('/api/v2/some/path', {
+      headers: { 'x-fail-mapper': '1' }
+    }).then(function (error) {
+      assert.expect(error.fromErrorMiddleware);
+      assert.equal('OptionMapperError', error.message);
+    });
+  });
+
+  it('forwards 4xx', function () {
+    proxyClient.fetch('/api/v2/server-error', {
+      method: 'POST',
+      json: { some: { body: 'data' } },
+      qs: { more: 'query stuff' },
+      headers: { 'x-my-header': 'header-value' }
+    }).asPromise().then(function (results) {
+      assert.equal(401, results[0].statusCode);
+      assert.equal('header-value', results[1].headers['x-my-header']);
+    });
+  });
+
+  it('wraps network errors', function () {
+    proxyClient.fetch('/api/v2/network-error', {
+      method: 'POST',
+      json: { some: { body: 'data' } },
+      qs: { more: 'query stuff' }
+    }).then(function (error) {
+      assert.expect(error.fromErrorMiddleware);
+      assert.equal('ECONNRESET', error.code);
+    });
   });
 });

--- a/test/gofer-proxy.test.js
+++ b/test/gofer-proxy.test.js
@@ -4,7 +4,7 @@ var assert = require('assertive');
 var goferProxy = require('../');
 
 describe('gofer-proxy', function () {
-  it('is empty', function () {
-    assert.deepEqual({}, goferProxy);
+  it('is a function', function () {
+    assert.hasType(Function, goferProxy);
   });
 });


### PR DESCRIPTION
This code currently lives in `gofer/proxy`. To make it easier to test it across gofer versions (and to make it safe to use in an app that might use multiple service clients based on different versions of gofer), this pulls it into its own dedicated package.