### PR TITLE
Handle gzip encoded bodies w/ gofer 3

### DIFF
--- a/lib/gofer-proxy.js
+++ b/lib/gofer-proxy.js
@@ -40,7 +40,7 @@ function goferProxy(client, req, res, next) {
   var parsed = url.parse(req.url, true);
   var options = {
     method: req.method,
-    headers: _.omit(req.headers, 'host'),
+    headers: _.omit(req.headers, 'host', 'accept-encoding'),
     body: req,
     qs: _.omit(parsed.query, 'callback'),
     minStatusCode: 200,
@@ -48,18 +48,26 @@ function goferProxy(client, req, res, next) {
   };
   var proxyReq = client.fetch(parsed.pathname, options);
 
-  function handleProxyResponse(proxyRes) {
+  function handleGofer2Stream(requestStream) {
     return new Bluebird(function forward(resolve, reject) {
-      proxyRes.on('error', reject);
-      if ('statusCode' in proxyRes) {
-        res.statusCode = proxyRes.statusCode;
-      }
-      proxyRes.pipe(res);
-      return proxyRes.on('end', resolve);
+      requestStream.on('error', reject);
+      requestStream.pipe(res);
+      requestStream.on('end', resolve);
     });
   }
+
+  function handleGofer3Response(proxyRes) {
+    return proxyRes.rawBody().then(function writeBody(resBody) {
+      var safeHeaders = _.omit(proxyRes.headers,
+        'content-encoding', 'content-length', 'transfer-encoding');
+      safeHeaders['Content-Length'] = resBody.length;
+      res.writeHead(proxyRes.statusCode, safeHeaders);
+      res.end(resBody);
+    });
+  }
+
   var piped = typeof proxyReq.pipe === 'function' ?
-    handleProxyResponse(proxyReq) : proxyReq.then(handleProxyResponse);
+    handleGofer2Stream(proxyReq) : proxyReq.then(handleGofer3Response);
   piped.then(null, next);
 }
 module.exports = goferProxy;


### PR DESCRIPTION
There's some edge cases where upstream proxies expect to handle all gzip encoding themselves. This cleanly removes all content encoding headers on the way in- and out.